### PR TITLE
fix: workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,4 +20,4 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.ORG_GITHUB_READ_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
   test-on-linux:
     strategy:
       matrix:
-        os-version: [ 18.04, 20.04, 22.04 ]
+        os-version: [ 20.04, 22.04 ]
         go-version: [ 1.16, 1.17, 1.18, 1.19 ]
     runs-on: ubuntu-${{ matrix.os-version }}
     steps:


### PR DESCRIPTION
- remove deprecated test runner os version
  - https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/
- fix github_token for release
  - https://docs.github.com/en/actions/security-guides/automatic-token-authentication