### PR TITLE
ci: Upgrade GitHub Actions and GoReleaser versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           go-version-file: "go.mod"
       - name: Release with goreleaser
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
           args: release --clean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
-      - uses: actions/setup-go@v3
+        uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
       - name: Release with goreleaser

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 project_name: autopprof
 
 before:
@@ -5,8 +7,8 @@ before:
     - go mod tidy
     - gofmt -w .
 
-build:
-  skip: true
+builds:
+  - skip: true
 
 archives:
   - id: archive


### PR DESCRIPTION
**Overview**
This PR upgrades the versions of several GitHub Actions in our CI workflow to resolve errors caused by an outdated goreleaser/goreleaser-action. The .goreleaser.yml configuration has also been updated to be compatible with the new version.
failed release workflow: https://github.com/daangn/autopprof/actions/runs/15769646754/job/44452171621

**Key Changes**
- Upgraded `goreleaser/goreleaser-action` (v1 → v6)
  - Updated the action to the latest stable version (v6) to fix errors that were occurring with the v1 action.
  - Updated `.goreleaser.yml` configuration (build → builds)
    - In GoReleaser versions after v1, the `build` field was deprecated and replaced with the `builds` list. The configuration has been modified to align with this new structure.
- Upgraded `actions/checkout` and `actions/setup-go`
