### PR TITLE
feat: expose Option.ReportTimeout

### DIFF
--- a/autopprof.go
+++ b/autopprof.go
@@ -14,14 +14,13 @@ import (
 	"github.com/daangn/autopprof/v2/report"
 )
 
-const reportTimeout = 5 * time.Second
-
 type autoPprof struct {
 	watchInterval               time.Duration
 	minConsecutiveOverThreshold int
 
-	reporter report.Reporter
-	app      string
+	reporter      report.Reporter
+	reportTimeout time.Duration
+	app           string
 
 	disableCPUProf       bool
 	disableMemProf       bool
@@ -88,11 +87,16 @@ func start(opt Option) error {
 	if app == "" {
 		app = defaultApp
 	}
+	reportTimeout := defaultReportTimeout
+	if opt.ReportTimeout > 0 {
+		reportTimeout = opt.ReportTimeout
+	}
 	profr := newDefaultProfiler(defaultCPUProfilingDuration)
 	ap := &autoPprof{
 		watchInterval:               defaultWatchInterval,
 		minConsecutiveOverThreshold: defaultMinConsecutiveOverThreshold,
 		reporter:                    opt.Reporter,
+		reportTimeout:               reportTimeout,
 		app:                         app,
 		disableCPUProf:              opt.DisableCPUProf,
 		disableMemProf:              opt.DisableMemProf,
@@ -301,7 +305,7 @@ func (ap *autoPprof) fireReport(runner *metricRunner, value float64) error {
 		info.Comment = defaultComment(runner.name, value, runner.threshold)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), reportTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), ap.reportTimeout)
 	defer cancel()
 	return ap.reporter.Report(ctx, result.Reader, info)
 }

--- a/autopprof_test.go
+++ b/autopprof_test.go
@@ -131,6 +131,7 @@ func newTestAp(t *testing.T, reporter report.Reporter) *autoPprof {
 		watchInterval:               20 * time.Millisecond,
 		minConsecutiveOverThreshold: 3,
 		reporter:                    reporter,
+		reportTimeout:               defaultReportTimeout,
 		cascadedRunners:             make(map[string]*metricRunner),
 		stopC:                       make(chan struct{}),
 	}

--- a/error.go
+++ b/error.go
@@ -15,6 +15,9 @@ var (
 	ErrInvalidGoroutineThreshold = errors.New(
 		"autopprof: goroutine threshold value must be greater than to 0",
 	)
+	ErrInvalidReportTimeout = errors.New(
+		"autopprof: report timeout must be a non-negative duration",
+	)
 	ErrNilReporter         = errors.New("autopprof: Reporter can't be nil")
 	ErrDisableAllProfiling = errors.New("autopprof: all profiling is disabled")
 

--- a/option.go
+++ b/option.go
@@ -14,6 +14,7 @@ const (
 	defaultWatchInterval               = 5 * time.Second
 	defaultCPUProfilingDuration        = 10 * time.Second
 	defaultMinConsecutiveOverThreshold = 12 // 12 * 5s == 1 minute
+	defaultReportTimeout               = 5 * time.Second
 )
 
 // Option is the configuration for autopprof.
@@ -50,6 +51,10 @@ type Option struct {
 	// implement the report.Reporter interface.
 	Reporter report.Reporter
 
+	// ReportTimeout is the per-call timeout passed to Reporter.Report
+	// as the ctx deadline. Defaults to 5s when left zero.
+	ReportTimeout time.Duration
+
 	// App is embedded in built-in CPU/Mem/Goroutine filenames as the
 	// "<app>" segment. Defaults to "autopprof" when left empty.
 	App string
@@ -73,6 +78,9 @@ func (o Option) validate() error {
 	}
 	if o.GoroutineThreshold < 0 {
 		return ErrInvalidGoroutineThreshold
+	}
+	if o.ReportTimeout < 0 {
+		return ErrInvalidReportTimeout
 	}
 	if o.Reporter == nil {
 		return ErrNilReporter


### PR DESCRIPTION
The Reporter.Report ctx deadline was hard-coded to 5 seconds. Promote it to a configurable Option.ReportTimeout with the same default, so callers with slow upload paths (large Slack uploads, congested networks) can extend the window without forking the library.
