### PR TITLE
feat: expose Option.WatchInterval and Option.ReportCooldown

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ package main
 import (
 	"errors"
 	"log"
+	"time"
 
 	"github.com/daangn/autopprof/v2"
 	"github.com/daangn/autopprof/v2/report"
@@ -39,9 +40,11 @@ import (
 
 func main() {
 	err := autopprof.Start(autopprof.Option{
-		App:          "YOUR_APP_NAME",
-		CPUThreshold: 0.8, // Default: 0.75.
-		MemThreshold: 0.8, // Default: 0.75.
+		App:            "YOUR_APP_NAME",
+		CPUThreshold:   0.8,              // Default: 0.75.
+		MemThreshold:   0.8,              // Default: 0.75.
+		WatchInterval:  10 * time.Second, // Default: 5s. How often each metric is sampled.
+		ReportCooldown: 5 * time.Minute,  // Default: 1m. Min gap before re-reporting the same metric.
 		Reporter: report.NewSlackReporter(
 			&report.SlackReporterOption{
 				Token:     "YOUR_TOKEN_HERE",

--- a/autopprof.go
+++ b/autopprof.go
@@ -15,8 +15,8 @@ import (
 )
 
 type autoPprof struct {
-	watchInterval               time.Duration
-	minConsecutiveOverThreshold int
+	watchInterval  time.Duration
+	reportCooldown time.Duration
 
 	reporter      report.Reporter
 	reportTimeout time.Duration
@@ -47,6 +47,13 @@ type metricRunner struct {
 	name      string
 	threshold float64
 	interval  time.Duration
+
+	// minConsecutiveOverThreshold is the number of consecutive
+	// over-threshold ticks to suppress after a report fires — the
+	// ReportCooldown converted to this runner's interval (rounded to the
+	// nearest tick, floor one). Cached at registration so the watch loop
+	// stays arithmetic-free.
+	minConsecutiveOverThreshold int
 }
 
 // globalAp is the running instance, or nil before Start. Access is
@@ -91,21 +98,29 @@ func start(opt Option) error {
 	if opt.ReportTimeout > 0 {
 		reportTimeout = opt.ReportTimeout
 	}
+	watchInterval := defaultWatchInterval
+	if opt.WatchInterval > 0 {
+		watchInterval = opt.WatchInterval
+	}
+	reportCooldown := defaultReportCooldown
+	if opt.ReportCooldown > 0 {
+		reportCooldown = opt.ReportCooldown
+	}
 	profr := newDefaultProfiler(defaultCPUProfilingDuration)
 	ap := &autoPprof{
-		watchInterval:               defaultWatchInterval,
-		minConsecutiveOverThreshold: defaultMinConsecutiveOverThreshold,
-		reporter:                    opt.Reporter,
-		reportTimeout:               reportTimeout,
-		app:                         app,
-		disableCPUProf:              opt.DisableCPUProf,
-		disableMemProf:              opt.DisableMemProf,
-		disableGoroutineProf:        opt.DisableGoroutineProf,
-		cgroupQueryer:               cgroupQryer,
-		runtimeQueryer:              runtimeQryer,
-		profiler:                    profr,
-		cascadedRunners:             make(map[string]*metricRunner),
-		stopC:                       make(chan struct{}),
+		watchInterval:        watchInterval,
+		reportCooldown:       reportCooldown,
+		reporter:             opt.Reporter,
+		reportTimeout:        reportTimeout,
+		app:                  app,
+		disableCPUProf:       opt.DisableCPUProf,
+		disableMemProf:       opt.DisableMemProf,
+		disableGoroutineProf: opt.DisableGoroutineProf,
+		cgroupQueryer:        cgroupQryer,
+		runtimeQueryer:       runtimeQryer,
+		profiler:             profr,
+		cascadedRunners:      make(map[string]*metricRunner),
+		stopC:                make(chan struct{}),
 	}
 	if !ap.disableCPUProf {
 		if err := ap.loadCPUQuota(); err != nil {
@@ -196,7 +211,7 @@ func (ap *autoPprof) registerBuiltinMetrics(opt Option) {
 }
 
 func (ap *autoPprof) registerBuiltIn(m Metric) {
-	runner := newRunner(m, ap.watchInterval)
+	runner := newRunner(m, ap.watchInterval, ap.reportCooldown)
 	ap.cascadedRunners[runner.name] = runner
 	ap.wg.Add(1)
 	go func() {
@@ -214,7 +229,7 @@ func (ap *autoPprof) registerMetric(m Metric) error {
 		return ErrNotStarted
 	default:
 	}
-	runner := newRunner(m, ap.watchInterval)
+	runner := newRunner(m, ap.watchInterval, ap.reportCooldown)
 	ap.wg.Add(1)
 	go func() {
 		defer ap.wg.Done()
@@ -224,18 +239,26 @@ func (ap *autoPprof) registerMetric(m Metric) error {
 }
 
 // newRunner caches Metric's meta values so the watch loop uses a
-// stable name/threshold/interval even if the implementation mutates
-// them later.
-func newRunner(m Metric, globalInterval time.Duration) *metricRunner {
+// stable name/threshold/interval (and the derived cooldown tick count)
+// even if the implementation mutates them later.
+func newRunner(m Metric, globalInterval, cooldown time.Duration) *metricRunner {
 	interval := m.Interval()
 	if interval == 0 {
 		interval = globalInterval
 	}
+	// Convert the wall-clock cooldown into this runner's tick count,
+	// rounded to the nearest tick with a floor of one so a metric is
+	// reported at most once per sample.
+	n := int((cooldown + interval/2) / interval)
+	if n < 1 {
+		n = 1
+	}
 	return &metricRunner{
-		metric:    m,
-		name:      m.Name(),
-		threshold: m.Threshold(),
-		interval:  interval,
+		metric:                      m,
+		name:                        m.Name(),
+		threshold:                   m.Threshold(),
+		interval:                    interval,
+		minConsecutiveOverThreshold: n,
 	}
 }
 
@@ -272,7 +295,7 @@ func (ap *autoPprof) watchMetric(runner *metricRunner, isBuiltin bool) {
 				}
 			}
 			cnt++
-			if cnt >= ap.minConsecutiveOverThreshold {
+			if cnt >= runner.minConsecutiveOverThreshold {
 				cnt = 0
 			}
 		case <-ap.stopC:

--- a/autopprof.go
+++ b/autopprof.go
@@ -47,13 +47,6 @@ type metricRunner struct {
 	name      string
 	threshold float64
 	interval  time.Duration
-
-	// minConsecutiveOverThreshold is the number of consecutive
-	// over-threshold ticks to suppress after a report fires — the
-	// ReportCooldown converted to this runner's interval (rounded to the
-	// nearest tick, floor one). Cached at registration so the watch loop
-	// stays arithmetic-free.
-	minConsecutiveOverThreshold int
 }
 
 // globalAp is the running instance, or nil before Start. Access is
@@ -211,7 +204,7 @@ func (ap *autoPprof) registerBuiltinMetrics(opt Option) {
 }
 
 func (ap *autoPprof) registerBuiltIn(m Metric) {
-	runner := newRunner(m, ap.watchInterval, ap.reportCooldown)
+	runner := newRunner(m, ap.watchInterval)
 	ap.cascadedRunners[runner.name] = runner
 	ap.wg.Add(1)
 	go func() {
@@ -229,7 +222,7 @@ func (ap *autoPprof) registerMetric(m Metric) error {
 		return ErrNotStarted
 	default:
 	}
-	runner := newRunner(m, ap.watchInterval, ap.reportCooldown)
+	runner := newRunner(m, ap.watchInterval)
 	ap.wg.Add(1)
 	go func() {
 		defer ap.wg.Done()
@@ -239,37 +232,31 @@ func (ap *autoPprof) registerMetric(m Metric) error {
 }
 
 // newRunner caches Metric's meta values so the watch loop uses a
-// stable name/threshold/interval (and the derived cooldown tick count)
-// even if the implementation mutates them later.
-func newRunner(m Metric, globalInterval, cooldown time.Duration) *metricRunner {
+// stable name/threshold/interval even if the implementation mutates
+// them later.
+func newRunner(m Metric, globalInterval time.Duration) *metricRunner {
 	interval := m.Interval()
 	if interval == 0 {
 		interval = globalInterval
 	}
-	// Convert the wall-clock cooldown into this runner's tick count,
-	// rounded to the nearest tick with a floor of one so a metric is
-	// reported at most once per sample.
-	n := int((cooldown + interval/2) / interval)
-	if n < 1 {
-		n = 1
-	}
 	return &metricRunner{
-		metric:                      m,
-		name:                        m.Name(),
-		threshold:                   m.Threshold(),
-		interval:                    interval,
-		minConsecutiveOverThreshold: n,
+		metric:    m,
+		name:      m.Name(),
+		threshold: m.Threshold(),
+		interval:  interval,
 	}
 }
 
-// watchMetric runs the unified watch loop. minConsecutiveOverThreshold
-// debounces repeat fires: report on the first tick above threshold,
-// suppress until the counter drops below threshold or wraps around.
+// watchMetric runs the unified watch loop. reportCooldown debounces
+// repeat fires: report on the first tick above threshold, then suppress
+// further reports for that metric until the cooldown has elapsed.
+// Dropping below the threshold re-arms an immediate report on the next
+// breach.
 func (ap *autoPprof) watchMetric(runner *metricRunner, isBuiltin bool) {
 	ticker := time.NewTicker(runner.interval)
 	defer ticker.Stop()
 
-	var cnt int
+	var lastReport time.Time
 	for {
 		select {
 		case <-ticker.C:
@@ -281,10 +268,11 @@ func (ap *autoPprof) watchMetric(runner *metricRunner, isBuiltin bool) {
 				return
 			}
 			if value < runner.threshold {
-				cnt = 0
+				lastReport = time.Time{}
 				continue
 			}
-			if cnt == 0 {
+			now := time.Now()
+			if lastReport.IsZero() || now.Sub(lastReport) >= ap.reportCooldown {
 				if err := ap.fireReport(runner, value); err != nil {
 					log.Println(fmt.Errorf(
 						"autopprof: metric %q report failed: %w", runner.name, err,
@@ -293,10 +281,7 @@ func (ap *autoPprof) watchMetric(runner *metricRunner, isBuiltin bool) {
 				if isBuiltin {
 					ap.cascadeBuiltIn(runner.name)
 				}
-			}
-			cnt++
-			if cnt >= runner.minConsecutiveOverThreshold {
-				cnt = 0
+				lastReport = now
 			}
 		case <-ap.stopC:
 			return

--- a/autopprof_test.go
+++ b/autopprof_test.go
@@ -107,6 +107,12 @@ func TestOption_validate(t *testing.T) {
 		{"negative interval",
 			Option{Reporter: stub, Metrics: []Metric{&fakeMetric{nameVal: "x", thresholdVal: 1, intervalVal: -time.Second}}},
 			ErrInvalidMetric},
+		{"negative WatchInterval",
+			Option{Reporter: stub, WatchInterval: -time.Second},
+			ErrInvalidWatchInterval},
+		{"negative ReportCooldown",
+			Option{Reporter: stub, ReportCooldown: -time.Second},
+			ErrInvalidReportCooldown},
 		{"valid custom metric",
 			Option{Reporter: stub, Metrics: []Metric{validMetric}},
 			nil},
@@ -120,7 +126,6 @@ func TestOption_validate(t *testing.T) {
 	}
 }
 
-
 // -------------------------------------------------------------------
 // Built-in Metric: watch loop & Reporter routing
 // -------------------------------------------------------------------
@@ -128,12 +133,12 @@ func TestOption_validate(t *testing.T) {
 func newTestAp(t *testing.T, reporter report.Reporter) *autoPprof {
 	t.Helper()
 	return &autoPprof{
-		watchInterval:               20 * time.Millisecond,
-		minConsecutiveOverThreshold: 3,
-		reporter:                    reporter,
-		reportTimeout:               defaultReportTimeout,
-		cascadedRunners:             make(map[string]*metricRunner),
-		stopC:                       make(chan struct{}),
+		watchInterval:   20 * time.Millisecond,
+		reportCooldown:  60 * time.Millisecond, // 3 ticks @20ms
+		reporter:        reporter,
+		reportTimeout:   defaultReportTimeout,
+		cascadedRunners: make(map[string]*metricRunner),
+		stopC:           make(chan struct{}),
 	}
 }
 
@@ -271,7 +276,7 @@ func TestWatchMetric_debounce(t *testing.T) {
 		},
 	}
 	ap := newTestAp(t, mockReporter)
-	ap.minConsecutiveOverThreshold = 3
+	ap.reportCooldown = 60 * time.Millisecond // debounce count 3 @20ms
 	if err := ap.registerMetric(fm); err != nil {
 		t.Fatal(err)
 	}
@@ -282,6 +287,39 @@ func TestWatchMetric_debounce(t *testing.T) {
 	got := reported.Load()
 	if got < 2 || got > 3 {
 		t.Errorf("expected 2-3 reports with debounce=3, got %d", got)
+	}
+}
+
+func TestNewRunner_reportCooldownToTickCount(t *testing.T) {
+	const global = 5 * time.Second
+	testCases := []struct {
+		name           string
+		metricInterval time.Duration // 0 => inherit global
+		cooldown       time.Duration
+		wantInterval   time.Duration
+		wantCount      int
+	}{
+		{"default 1m at 5s global", 0, time.Minute, global, 12},
+		{"2m at 5s", 0, 2 * time.Minute, global, 24},
+		{"metric interval overrides global", 10 * time.Second, time.Minute, 10 * time.Second, 6},
+		{"rounds to nearest up", 0, 13 * time.Second, global, 3},   // 2.6 -> 3
+		{"rounds to nearest down", 0, 12 * time.Second, global, 2}, // 2.4 -> 2
+		{"cooldown below interval floors to one", 0, time.Second, global, 1},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &fakeMetric{
+				nameVal: "m", thresholdVal: 1, intervalVal: tc.metricInterval,
+				queryFn: func() (float64, error) { return 0, nil },
+			}
+			r := newRunner(m, global, tc.cooldown)
+			if r.interval != tc.wantInterval {
+				t.Errorf("interval: want %v, got %v", tc.wantInterval, r.interval)
+			}
+			if r.minConsecutiveOverThreshold != tc.wantCount {
+				t.Errorf("count: want %d, got %d", tc.wantCount, r.minConsecutiveOverThreshold)
+			}
+		})
 	}
 }
 
@@ -321,7 +359,7 @@ func TestCascadeBuiltIn(t *testing.T) {
 	ap.cgroupQueryer = mockCG
 	ap.runtimeQueryer = mockRT
 	ap.profiler = mockProf
-	ap.minConsecutiveOverThreshold = 1000
+	ap.reportCooldown = 20 * time.Second // count 1000 @20ms — suppress repeats
 	ap.registerBuiltIn(&cpuMetric{threshold: 0.5, cg: mockCG, p: mockProf})
 	ap.registerBuiltIn(&memMetric{threshold: 0.5, cg: mockCG, p: mockProf})
 	ap.registerBuiltIn(&goroutineMetric{threshold: 5, rt: mockRT, p: mockProf})

--- a/autopprof_test.go
+++ b/autopprof_test.go
@@ -134,7 +134,7 @@ func newTestAp(t *testing.T, reporter report.Reporter) *autoPprof {
 	t.Helper()
 	return &autoPprof{
 		watchInterval:   20 * time.Millisecond,
-		reportCooldown:  60 * time.Millisecond, // 3 ticks @20ms
+		reportCooldown:  60 * time.Millisecond, // 60ms cooldown for watch-loop tests
 		reporter:        reporter,
 		reportTimeout:   defaultReportTimeout,
 		cascadedRunners: make(map[string]*metricRunner),
@@ -252,7 +252,7 @@ func TestWatchMetric_builtinGoroutine_routesToReporter(t *testing.T) {
 }
 
 // -------------------------------------------------------------------
-// Debounce (minConsecutiveOverThreshold)
+// Debounce (ReportCooldown)
 // -------------------------------------------------------------------
 
 func TestWatchMetric_debounce(t *testing.T) {
@@ -276,7 +276,7 @@ func TestWatchMetric_debounce(t *testing.T) {
 		},
 	}
 	ap := newTestAp(t, mockReporter)
-	ap.reportCooldown = 60 * time.Millisecond // debounce count 3 @20ms
+	ap.reportCooldown = 60 * time.Millisecond // 60ms cooldown, 20ms ticks
 	if err := ap.registerMetric(fm); err != nil {
 		t.Fatal(err)
 	}
@@ -286,40 +286,52 @@ func TestWatchMetric_debounce(t *testing.T) {
 	time.Sleep(170 * time.Millisecond)
 	got := reported.Load()
 	if got < 2 || got > 3 {
-		t.Errorf("expected 2-3 reports with debounce=3, got %d", got)
+		t.Errorf("expected 2-3 reports with 60ms cooldown, got %d", got)
 	}
 }
 
-func TestNewRunner_reportCooldownToTickCount(t *testing.T) {
-	const global = 5 * time.Second
-	testCases := []struct {
-		name           string
-		metricInterval time.Duration // 0 => inherit global
-		cooldown       time.Duration
-		wantInterval   time.Duration
-		wantCount      int
-	}{
-		{"default 1m at 5s global", 0, time.Minute, global, 12},
-		{"2m at 5s", 0, 2 * time.Minute, global, 24},
-		{"metric interval overrides global", 10 * time.Second, time.Minute, 10 * time.Second, 6},
-		{"rounds to nearest up", 0, 13 * time.Second, global, 3},   // 2.6 -> 3
-		{"rounds to nearest down", 0, 12 * time.Second, global, 2}, // 2.4 -> 2
-		{"cooldown below interval floors to one", 0, time.Second, global, 1},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			m := &fakeMetric{
-				nameVal: "m", thresholdVal: 1, intervalVal: tc.metricInterval,
-				queryFn: func() (float64, error) { return 0, nil },
-			}
-			r := newRunner(m, global, tc.cooldown)
-			if r.interval != tc.wantInterval {
-				t.Errorf("interval: want %v, got %v", tc.wantInterval, r.interval)
-			}
-			if r.minConsecutiveOverThreshold != tc.wantCount {
-				t.Errorf("count: want %d, got %d", tc.wantCount, r.minConsecutiveOverThreshold)
-			}
+// TestWatchMetric_cooldownReArmsBelowThreshold verifies the cooldown is
+// per-episode: dropping below the threshold re-arms an immediate report
+// on the next breach, even while the cooldown window is still open.
+func TestWatchMetric_cooldownReArmsBelowThreshold(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	var reported atomic.Int32
+	mockReporter := report.NewMockReporter(ctrl)
+	mockReporter.EXPECT().Report(gomock.Any(), gomock.Any(), gomock.Any()).
+		AnyTimes().
+		DoAndReturn(func(_ context.Context, _ io.Reader, _ report.ReportInfo) error {
+			reported.Add(1)
+			return nil
 		})
+
+	// Query per tick: over, over, under, over, over... With a 10s cooldown
+	// a pure time throttle would report once; the dip under threshold on
+	// the 3rd tick must re-arm so the 4th tick reports again.
+	var calls atomic.Int32
+	fm := &fakeMetric{
+		nameVal:      "rearm",
+		thresholdVal: 1,
+		intervalVal:  20 * time.Millisecond,
+		queryFn: func() (float64, error) {
+			if calls.Add(1) == 3 {
+				return 0, nil // under threshold → re-arm
+			}
+			return 100, nil // over threshold
+		},
+		collectFn: func(float64) (CollectResult, error) {
+			return CollectResult{Reader: bytes.NewReader([]byte("x"))}, nil
+		},
+	}
+	ap := newTestAp(t, mockReporter)
+	ap.reportCooldown = 10 * time.Second // only a re-arm can re-fire this fast
+	if err := ap.registerMetric(fm); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ap.stop() })
+
+	waitFor(t, func() bool { return reported.Load() >= 2 }, time.Second)
+	if got := reported.Load(); got != 2 {
+		t.Errorf("expected exactly 2 reports (breach + re-arm), got %d", got)
 	}
 }
 
@@ -359,7 +371,7 @@ func TestCascadeBuiltIn(t *testing.T) {
 	ap.cgroupQueryer = mockCG
 	ap.runtimeQueryer = mockRT
 	ap.profiler = mockProf
-	ap.reportCooldown = 20 * time.Second // count 1000 @20ms — suppress repeats
+	ap.reportCooldown = 20 * time.Second // long cooldown — suppress repeats
 	ap.registerBuiltIn(&cpuMetric{threshold: 0.5, cg: mockCG, p: mockProf})
 	ap.registerBuiltIn(&memMetric{threshold: 0.5, cg: mockCG, p: mockProf})
 	ap.registerBuiltIn(&goroutineMetric{threshold: 5, rt: mockRT, p: mockProf})

--- a/error.go
+++ b/error.go
@@ -18,6 +18,12 @@ var (
 	ErrInvalidReportTimeout = errors.New(
 		"autopprof: report timeout must be a non-negative duration",
 	)
+	ErrInvalidWatchInterval = errors.New(
+		"autopprof: watch interval must be a non-negative duration",
+	)
+	ErrInvalidReportCooldown = errors.New(
+		"autopprof: report cooldown must be a non-negative duration",
+	)
 	ErrNilReporter         = errors.New("autopprof: Reporter can't be nil")
 	ErrDisableAllProfiling = errors.New("autopprof: all profiling is disabled")
 

--- a/option.go
+++ b/option.go
@@ -7,14 +7,14 @@ import (
 )
 
 const (
-	defaultApp                         = "autopprof"
-	defaultCPUThreshold                = 0.75
-	defaultMemThreshold                = 0.75
-	defaultGoroutineThreshold          = 50000
-	defaultWatchInterval               = 5 * time.Second
-	defaultCPUProfilingDuration        = 10 * time.Second
-	defaultMinConsecutiveOverThreshold = 12 // 12 * 5s == 1 minute
-	defaultReportTimeout               = 5 * time.Second
+	defaultApp                  = "autopprof"
+	defaultCPUThreshold         = 0.75
+	defaultMemThreshold         = 0.75
+	defaultGoroutineThreshold   = 50000
+	defaultWatchInterval        = 5 * time.Second
+	defaultCPUProfilingDuration = 10 * time.Second
+	defaultReportCooldown       = 1 * time.Minute
+	defaultReportTimeout        = 5 * time.Second
 )
 
 // Option is the configuration for autopprof.
@@ -55,6 +55,21 @@ type Option struct {
 	// as the ctx deadline. Defaults to 5s when left zero.
 	ReportTimeout time.Duration
 
+	// WatchInterval is how often each metric is sampled against its
+	// threshold. It applies to the built-in CPU/Mem/Goroutine watchers
+	// and to any custom Metric that returns 0 from Interval(). Defaults
+	// to 5s when left zero.
+	WatchInterval time.Duration
+
+	// ReportCooldown is the minimum time before the same metric is
+	// reported again while it stays over threshold. A report still fires
+	// immediately on the first breach; subsequent reports for that metric
+	// are suppressed for this long. The cooldown is quantized to the
+	// metric's watch interval (rounded to the nearest tick, with a floor
+	// of one tick), so a metric is reported at most once per sample.
+	// Defaults to 1m when left zero.
+	ReportCooldown time.Duration
+
 	// App is embedded in built-in CPU/Mem/Goroutine filenames as the
 	// "<app>" segment. Defaults to "autopprof" when left empty.
 	App string
@@ -81,6 +96,12 @@ func (o Option) validate() error {
 	}
 	if o.ReportTimeout < 0 {
 		return ErrInvalidReportTimeout
+	}
+	if o.WatchInterval < 0 {
+		return ErrInvalidWatchInterval
+	}
+	if o.ReportCooldown < 0 {
+		return ErrInvalidReportCooldown
 	}
 	if o.Reporter == nil {
 		return ErrNilReporter

--- a/option.go
+++ b/option.go
@@ -64,10 +64,10 @@ type Option struct {
 	// ReportCooldown is the minimum time before the same metric is
 	// reported again while it stays over threshold. A report still fires
 	// immediately on the first breach; subsequent reports for that metric
-	// are suppressed for this long. The cooldown is quantized to the
-	// metric's watch interval (rounded to the nearest tick, with a floor
-	// of one tick), so a metric is reported at most once per sample.
-	// Defaults to 1m when left zero.
+	// are suppressed until this much wall-clock time has elapsed. The
+	// elapsed check runs once per sample, so a metric is reported at most
+	// once per watch interval, and dropping below the threshold re-arms an
+	// immediate report on the next breach. Defaults to 1m when left zero.
 	ReportCooldown time.Duration
 
 	// App is embedded in built-in CPU/Mem/Goroutine filenames as the


### PR DESCRIPTION
WatchInterval (metric sampling period) and the repeat-report cooldown were both hard-coded (5s, and a 12-tick == 1m debounce). Promote them to configurable Options with the same defaults.

ReportCooldown is a time.Duration rather than a raw tick count: it is converted to each runner's interval (rounded to the nearest tick, floor one), so the cooldown means a consistent wall-clock gap for every metric regardless of its watch interval. The internal minConsecutiveOverThreshold moves from autoPprof onto metricRunner accordingly.

Zero falls back to the default; negative values are rejected via ErrInvalidWatchInterval / ErrInvalidReportCooldown.