### PR TITLE
feat: group Slack reports into one thread per TTL window

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ func main() {
 			&report.SlackReporterOption{
 				Token:     "YOUR_TOKEN_HERE",
 				ChannelID: "REPORT_CHANNEL_ID",
+				ThreadTTL: 10 * time.Minute, // Group this pod's reports into one thread per window. Default: 0 (one message per report).
 			},
 		),
 	})
@@ -65,6 +66,15 @@ func main() {
 ```
 
 > You can create a custom reporter by implementing the `report.Reporter` interface.
+
+> **Thread grouping (`ThreadTTL`)** — By default each report is posted as a
+> separate top-level Slack message, which gets noisy when a pod stays over
+> threshold or many pods share a channel. Set `ThreadTTL` to group all of a
+> single process's reports into one thread for that window; once the window
+> elapses, the next report opens a fresh thread. Enabling it posts one extra
+> header message per window to obtain a parent timestamp, since Slack's file
+> upload API returns no timestamp to thread replies on. The window is
+> per-process (in-memory), so each pod keeps its own thread.
 
 ## Custom metrics
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ func main() {
 			&report.SlackReporterOption{
 				Token:     "YOUR_TOKEN_HERE",
 				ChannelID: "REPORT_CHANNEL_ID",
-				ThreadTTL: 10 * time.Minute, // Group this pod's reports into one thread per window. Default: 0 (one message per report).
+				ThreadTTL: 10 * time.Minute, // Default: 1h. Groups this pod's reports into one thread per window; negative disables.
 			},
 		),
 	})
@@ -67,14 +67,15 @@ func main() {
 
 > You can create a custom reporter by implementing the `report.Reporter` interface.
 
-> **Thread grouping (`ThreadTTL`)** — By default each report is posted as a
-> separate top-level Slack message, which gets noisy when a pod stays over
-> threshold or many pods share a channel. Set `ThreadTTL` to group all of a
-> single process's reports into one thread for that window; once the window
-> elapses, the next report opens a fresh thread. Enabling it posts one extra
-> header message per window to obtain a parent timestamp, since Slack's file
-> upload API returns no timestamp to thread replies on. The window is
-> per-process (in-memory), so each pod keeps its own thread.
+> **Thread grouping (`ThreadTTL`)** — All of a single process's reports are
+> grouped into one Slack thread per time window (default 1h) to cut the noise
+> when a pod stays over threshold or many pods share a channel. Once the window
+> elapses, the next report opens a fresh thread. Set a custom duration to change
+> the window, or a negative value to disable threading (each report becomes its
+> own top-level message). Threading posts one extra header message per window to
+> obtain a parent timestamp, since Slack's file upload API returns no timestamp
+> to thread replies on. The window is per-process (in-memory), so each pod keeps
+> its own thread.
 
 ## Custom metrics
 

--- a/examples/example.go
+++ b/examples/example.go
@@ -61,6 +61,10 @@ func main() {
 			&report.SlackReporterOption{
 				Token:     "YOUR_TOKEN_HERE",
 				ChannelID: "REPORT_CHANNEL_ID",
+				// ThreadTTL groups this pod's reports into a single Slack
+				// thread for the window. Zero (the default) disables
+				// threading: each report is its own top-level message.
+				ThreadTTL: 5 * time.Minute,
 			},
 		),
 	})

--- a/examples/example.go
+++ b/examples/example.go
@@ -62,8 +62,9 @@ func main() {
 				Token:     "YOUR_TOKEN_HERE",
 				ChannelID: "REPORT_CHANNEL_ID",
 				// ThreadTTL groups this pod's reports into a single Slack
-				// thread for the window. Zero (the default) disables
-				// threading: each report is its own top-level message.
+				// thread for the window. Defaults to 1h when unset; set a
+				// negative value to disable threading (each report becomes
+				// its own top-level message).
 				ThreadTTL: 5 * time.Minute,
 			},
 		),

--- a/report/slack.go
+++ b/report/slack.go
@@ -5,22 +5,76 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"sync"
+	"time"
 
 	"github.com/slack-go/slack"
 )
+
+// slackClient is the subset of *slack.Client that SlackReporter needs.
+// Declaring it as an interface lets tests inject a fake to exercise the
+// thread-grouping logic without hitting the Slack API. *slack.Client
+// satisfies this interface.
+type slackClient interface {
+	PostMessageContext(ctx context.Context, channelID string, options ...slack.MsgOption) (string, string, error)
+	UploadFileV2Context(ctx context.Context, params slack.UploadFileV2Parameters) (*slack.FileSummary, error)
+}
+
+// clock abstracts time.Now so tests can drive the TTL window
+// deterministically.
+type clock interface {
+	Now() time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
 
 // SlackReporter is the reporter to send the profiling report to the
 // specific Slack channel.
 type SlackReporter struct {
 	channelID string
 
-	client *slack.Client
+	client slackClient
+
+	// threadTTL groups this process's reports into a single Slack thread
+	// for the given window. Zero or negative disables threading: every
+	// report is uploaded as its own top-level message (legacy behavior).
+	threadTTL time.Duration
+
+	// hostname identifies this pod in the thread header. Resolved once at
+	// construction.
+	hostname string
+
+	// clock is realClock in production; tests inject a fake to drive the
+	// TTL window deterministically.
+	clock clock
+
+	// mu guards the thread state below. ensureThread holds it across the
+	// (fast) PostMessage call so concurrent first-reports can't each open
+	// a separate thread.
+	mu              sync.Mutex
+	threadTS        string
+	threadStartedAt time.Time
 }
 
 // SlackReporterOption is the option for the Slack reporter.
 type SlackReporterOption struct {
 	Token     string
 	ChannelID string
+
+	// ThreadTTL groups all of this process's reports into a single Slack
+	// thread for the duration of the window, measured from when the
+	// thread was opened. Once the window elapses, the next report opens a
+	// fresh thread. Zero or negative (the default) disables threading:
+	// each report is posted as a separate top-level message, preserving
+	// the previous behavior.
+	//
+	// Enabling threading posts one extra header message per window to
+	// obtain a parent timestamp, because Slack's file upload API returns
+	// no timestamp to thread replies on.
+	ThreadTTL time.Duration
 }
 
 // NewSlackReporter returns the new SlackReporter.
@@ -28,22 +82,78 @@ func NewSlackReporter(opt *SlackReporterOption) *SlackReporter {
 	return &SlackReporter{
 		channelID: opt.ChannelID,
 		client:    slack.New(opt.Token),
+		threadTTL: opt.ThreadTTL,
+		hostname:  hostname(),
+		clock:     realClock{},
 	}
 }
 
 // Report sends the profiling report to Slack. The filename and
 // comment are provided by autopprof (either supplied by the Metric's
-// Collect or filled with defaults).
+// Collect or filled with defaults). When ThreadTTL is set, reports
+// within the window are uploaded as replies under a shared thread
+// header instead of as separate top-level messages.
 func (s *SlackReporter) Report(
 	ctx context.Context, r io.Reader, info ReportInfo,
 ) error {
-	if err := s.reportProfile(ctx, r, info.Filename, info.Comment); err != nil {
+	var threadTS string
+	if s.threadTTL > 0 {
+		ts, err := s.ensureThread(ctx)
+		if err != nil {
+			return fmt.Errorf("autopprof: failed to open a Slack thread: %w", err)
+		}
+		threadTS = ts
+	}
+	if err := s.reportProfile(ctx, r, info.Filename, info.Comment, threadTS); err != nil {
 		return fmt.Errorf("autopprof: failed to upload a file to Slack channel: %w", err)
 	}
 	return nil
 }
 
-func (s *SlackReporter) reportProfile(ctx context.Context, r io.Reader, filename, comment string) error {
+// ensureThread returns the timestamp that reports should reply to,
+// opening (or rotating) the thread when none is active or the TTL
+// window has elapsed. It holds the lock across PostMessageContext so
+// concurrent callers open at most one thread per window.
+func (s *SlackReporter) ensureThread(ctx context.Context) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.clock.Now()
+	if s.threadTS != "" && now.Sub(s.threadStartedAt) < s.threadTTL {
+		return s.threadTS, nil
+	}
+
+	// Either no thread has been opened yet, or the window has elapsed
+	// (now - start >= TTL): open a new one. On error we leave the
+	// existing state untouched so the next breach simply retries — we do
+	// not fall back to a top-level upload (that would silently reintroduce
+	// the noise threading is meant to remove).
+	_, ts, err := s.client.PostMessageContext(
+		ctx, s.channelID, slack.MsgOptionText(s.header(now), false),
+	)
+	if err != nil {
+		return "", err
+	}
+	s.threadTS = ts
+	s.threadStartedAt = now
+	return ts, nil
+}
+
+// header is the text of the thread's parent message. It carries the
+// host so threads from different pods stay distinguishable, plus the
+// open time so successive windows from the same pod don't look
+// identical.
+func (s *SlackReporter) header(now time.Time) string {
+	return fmt.Sprintf(
+		":rotating_light:[autopprof] profiling reports — host %s (since %s)",
+		s.hostname, now.Format(time.RFC3339),
+	)
+}
+
+// reportProfile uploads a single profile. threadTS is empty when
+// threading is disabled, which yields the original top-level upload.
+// A non-empty threadTS posts the file as a reply in that thread.
+func (s *SlackReporter) reportProfile(ctx context.Context, r io.Reader, filename, comment, threadTS string) error {
 	fileSize := 0
 	reader := r
 	if seeker, ok := r.(io.Seeker); ok {
@@ -70,12 +180,23 @@ func (s *SlackReporter) reportProfile(ctx context.Context, r io.Reader, filename
 	}
 
 	_, err := s.client.UploadFileV2Context(ctx, slack.UploadFileV2Parameters{
-		Reader:         reader,
-		Filename:       filename,
-		FileSize:       fileSize,
-		Title:          filename,
-		InitialComment: comment,
-		Channel:        s.channelID,
+		Reader:          reader,
+		Filename:        filename,
+		FileSize:        fileSize,
+		Title:           filename,
+		InitialComment:  comment,
+		Channel:         s.channelID,
+		ThreadTimestamp: threadTS,
 	})
 	return err
+}
+
+// hostname returns this host's name for thread headers, falling back to
+// "unknown" when it can't be determined.
+func hostname() string {
+	h, err := os.Hostname()
+	if err != nil || h == "" {
+		return "unknown"
+	}
+	return h
 }

--- a/report/slack.go
+++ b/report/slack.go
@@ -67,22 +67,33 @@ type SlackReporterOption struct {
 	// ThreadTTL groups all of this process's reports into a single Slack
 	// thread for the duration of the window, measured from when the
 	// thread was opened. Once the window elapses, the next report opens a
-	// fresh thread. Zero or negative (the default) disables threading:
-	// each report is posted as a separate top-level message, preserving
-	// the previous behavior.
+	// fresh thread.
 	//
-	// Enabling threading posts one extra header message per window to
-	// obtain a parent timestamp, because Slack's file upload API returns
-	// no timestamp to thread replies on.
+	// Zero (the default) applies defaultThreadTTL (1h). Set a negative
+	// value to disable threading, posting each report as a separate
+	// top-level message.
+	//
+	// Threading posts one extra header message per window to obtain a
+	// parent timestamp, because Slack's file upload API returns no
+	// timestamp to thread replies on.
 	ThreadTTL time.Duration
 }
 
+// defaultThreadTTL is the thread-grouping window applied when
+// SlackReporterOption.ThreadTTL is left zero. A negative ThreadTTL
+// disables threading.
+const defaultThreadTTL = time.Hour
+
 // NewSlackReporter returns the new SlackReporter.
 func NewSlackReporter(opt *SlackReporterOption) *SlackReporter {
+	threadTTL := opt.ThreadTTL
+	if threadTTL == 0 {
+		threadTTL = defaultThreadTTL
+	}
 	return &SlackReporter{
 		channelID: opt.ChannelID,
 		client:    slack.New(opt.Token),
-		threadTTL: opt.ThreadTTL,
+		threadTTL: threadTTL,
 		hostname:  hostname(),
 		clock:     realClock{},
 	}

--- a/report/slack_test.go
+++ b/report/slack_test.go
@@ -1,0 +1,335 @@
+package report
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/slack-go/slack"
+)
+
+// fakeClock is a manually-advanced clock for deterministic TTL tests.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+type postCall struct {
+	channel string
+	text    string
+}
+
+// fakeSlackClient records calls and returns scripted timestamps/errors
+// in place of the real *slack.Client.
+type fakeSlackClient struct {
+	mu sync.Mutex
+
+	postCalls   []postCall
+	uploadCalls []slack.UploadFileV2Parameters
+
+	// postTS supplies the ts returned for each successful PostMessage in
+	// order; once exhausted a "ts-N" fallback is used.
+	postTS  []string
+	postErr error
+
+	uploadErr error
+}
+
+func (f *fakeSlackClient) PostMessageContext(
+	ctx context.Context, channelID string, options ...slack.MsgOption,
+) (string, string, error) {
+	text := ""
+	if _, values, err := slack.UnsafeApplyMsgOptions(
+		"token", channelID, "https://slack.com/api/", options...,
+	); err == nil {
+		text = values.Get("text")
+	}
+
+	f.mu.Lock()
+	f.postCalls = append(f.postCalls, postCall{channel: channelID, text: text})
+	n := len(f.postCalls)
+	postErr := f.postErr
+	ts := ""
+	if n-1 < len(f.postTS) {
+		ts = f.postTS[n-1]
+	}
+	f.mu.Unlock()
+
+	if postErr != nil {
+		return "", "", postErr
+	}
+	if ts == "" {
+		ts = "ts-" + strconv.Itoa(n)
+	}
+	return channelID, ts, nil
+}
+
+func (f *fakeSlackClient) UploadFileV2Context(
+	ctx context.Context, params slack.UploadFileV2Parameters,
+) (*slack.FileSummary, error) {
+	f.mu.Lock()
+	f.uploadCalls = append(f.uploadCalls, params)
+	uploadErr := f.uploadErr
+	f.mu.Unlock()
+
+	if uploadErr != nil {
+		return nil, uploadErr
+	}
+	return &slack.FileSummary{ID: "F1"}, nil
+}
+
+func (f *fakeSlackClient) snapshot() (posts []postCall, uploads []slack.UploadFileV2Parameters) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	posts = append(posts, f.postCalls...)
+	uploads = append(uploads, f.uploadCalls...)
+	return posts, uploads
+}
+
+// newTestReporter wires a SlackReporter to the fake client and clock.
+func newTestReporter(ttl time.Duration, clk *fakeClock, f *fakeSlackClient) *SlackReporter {
+	return &SlackReporter{
+		channelID: "C123",
+		client:    f,
+		threadTTL: ttl,
+		hostname:  "pod-abc",
+		clock:     clk,
+	}
+}
+
+func doReport(t *testing.T, r *SlackReporter) error {
+	t.Helper()
+	return r.Report(context.Background(), bytes.NewReader([]byte("profile-bytes")), ReportInfo{
+		MetricName: "cpu",
+		Filename:   "cpu.bin",
+		Comment:    ":rotating_light:[cpu]",
+	})
+}
+
+func TestSlackReporter_FirstReportOpensThread(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(1000, 0)}
+	f := &fakeSlackClient{postTS: []string{"100.1"}}
+	r := newTestReporter(time.Minute, clk, f)
+
+	if err := doReport(t, r); err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+
+	posts, uploads := f.snapshot()
+	if len(posts) != 1 {
+		t.Fatalf("want 1 header post, got %d", len(posts))
+	}
+	if !strings.Contains(posts[0].text, "pod-abc") ||
+		!strings.Contains(posts[0].text, ":rotating_light:") {
+		t.Errorf("header missing host/emoji: %q", posts[0].text)
+	}
+	if len(uploads) != 1 {
+		t.Fatalf("want 1 upload, got %d", len(uploads))
+	}
+	if uploads[0].ThreadTimestamp != "100.1" {
+		t.Errorf("upload thread_ts = %q, want 100.1", uploads[0].ThreadTimestamp)
+	}
+	if uploads[0].Channel != "C123" {
+		t.Errorf("upload channel = %q, want C123", uploads[0].Channel)
+	}
+}
+
+func TestSlackReporter_ReuseWithinTTL(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(1000, 0)}
+	f := &fakeSlackClient{postTS: []string{"100.1"}}
+	r := newTestReporter(time.Minute, clk, f)
+
+	if err := doReport(t, r); err != nil {
+		t.Fatalf("first Report: %v", err)
+	}
+	clk.advance(30 * time.Second) // still inside the 1m window
+	if err := doReport(t, r); err != nil {
+		t.Fatalf("second Report: %v", err)
+	}
+
+	posts, uploads := f.snapshot()
+	if len(posts) != 1 {
+		t.Fatalf("want 1 header post (reused thread), got %d", len(posts))
+	}
+	if len(uploads) != 2 {
+		t.Fatalf("want 2 uploads, got %d", len(uploads))
+	}
+	for i, u := range uploads {
+		if u.ThreadTimestamp != "100.1" {
+			t.Errorf("upload[%d] thread_ts = %q, want 100.1", i, u.ThreadTimestamp)
+		}
+	}
+}
+
+func TestSlackReporter_RotateAfterTTL(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(1000, 0)}
+	f := &fakeSlackClient{postTS: []string{"A", "B"}}
+	r := newTestReporter(time.Minute, clk, f)
+
+	if err := doReport(t, r); err != nil {
+		t.Fatalf("first Report: %v", err)
+	}
+	clk.advance(time.Minute) // exactly TTL: now-start >= TTL -> rotate
+	if err := doReport(t, r); err != nil {
+		t.Fatalf("second Report: %v", err)
+	}
+
+	posts, uploads := f.snapshot()
+	if len(posts) != 2 {
+		t.Fatalf("want 2 header posts (rotated), got %d", len(posts))
+	}
+	if len(uploads) != 2 {
+		t.Fatalf("want 2 uploads, got %d", len(uploads))
+	}
+	if uploads[0].ThreadTimestamp != "A" {
+		t.Errorf("upload[0] thread_ts = %q, want A", uploads[0].ThreadTimestamp)
+	}
+	if uploads[1].ThreadTimestamp != "B" {
+		t.Errorf("upload[1] thread_ts = %q, want B", uploads[1].ThreadTimestamp)
+	}
+}
+
+func TestSlackReporter_ThreadingDisabled(t *testing.T) {
+	for _, ttl := range []time.Duration{0, -time.Second} {
+		clk := &fakeClock{t: time.Unix(1000, 0)}
+		f := &fakeSlackClient{}
+		r := newTestReporter(ttl, clk, f)
+
+		if err := doReport(t, r); err != nil {
+			t.Fatalf("ttl=%v first Report: %v", ttl, err)
+		}
+		if err := doReport(t, r); err != nil {
+			t.Fatalf("ttl=%v second Report: %v", ttl, err)
+		}
+
+		posts, uploads := f.snapshot()
+		if len(posts) != 0 {
+			t.Errorf("ttl=%v: want 0 header posts, got %d", ttl, len(posts))
+		}
+		if len(uploads) != 2 {
+			t.Fatalf("ttl=%v: want 2 uploads, got %d", ttl, len(uploads))
+		}
+		for i, u := range uploads {
+			if u.ThreadTimestamp != "" {
+				t.Errorf("ttl=%v upload[%d] thread_ts = %q, want empty", ttl, i, u.ThreadTimestamp)
+			}
+		}
+	}
+}
+
+func TestSlackReporter_ConcurrentReportsOpenOneThread(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(1000, 0)}
+	f := &fakeSlackClient{postTS: []string{"only"}}
+	r := newTestReporter(time.Hour, clk, f)
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			if err := doReport(t, r); err != nil {
+				t.Errorf("Report: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	posts, uploads := f.snapshot()
+	if len(posts) != 1 {
+		t.Fatalf("want exactly 1 header post, got %d", len(posts))
+	}
+	if len(uploads) != n {
+		t.Fatalf("want %d uploads, got %d", n, len(uploads))
+	}
+	for i, u := range uploads {
+		if u.ThreadTimestamp != "only" {
+			t.Errorf("upload[%d] thread_ts = %q, want only", i, u.ThreadTimestamp)
+		}
+	}
+}
+
+func TestSlackReporter_PostMessageFailureNotPoisoned(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(1000, 0)}
+	f := &fakeSlackClient{postErr: errors.New("boom"), postTS: []string{"", "X"}}
+	r := newTestReporter(time.Minute, clk, f)
+
+	if err := doReport(t, r); err == nil {
+		t.Fatal("want error when PostMessage fails, got nil")
+	}
+	if _, uploads := f.snapshot(); len(uploads) != 0 {
+		t.Fatalf("want 0 uploads after header failure, got %d", len(uploads))
+	}
+	if r.threadTS != "" {
+		t.Fatalf("thread state poisoned after failure: threadTS=%q", r.threadTS)
+	}
+
+	// Recovery: a later breach must retry the header and succeed.
+	f.mu.Lock()
+	f.postErr = nil
+	f.mu.Unlock()
+
+	if err := doReport(t, r); err != nil {
+		t.Fatalf("recovery Report: %v", err)
+	}
+	posts, uploads := f.snapshot()
+	if len(posts) != 2 { // one failed attempt + one success
+		t.Errorf("want 2 header attempts, got %d", len(posts))
+	}
+	if len(uploads) != 1 {
+		t.Fatalf("want 1 upload after recovery, got %d", len(uploads))
+	}
+	if uploads[0].ThreadTimestamp != "X" {
+		t.Errorf("recovered upload thread_ts = %q, want X", uploads[0].ThreadTimestamp)
+	}
+}
+
+func TestSlackReporter_UploadFailureKeepsThread(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(1000, 0)}
+	f := &fakeSlackClient{postTS: []string{"X"}, uploadErr: errors.New("boom")}
+	r := newTestReporter(time.Minute, clk, f)
+
+	if err := doReport(t, r); err == nil {
+		t.Fatal("want error when upload fails, got nil")
+	}
+	if r.threadTS != "X" {
+		t.Fatalf("threadTS rolled back to %q, want X", r.threadTS)
+	}
+
+	// Upload recovers; still inside the window -> reuse thread, no new header.
+	f.mu.Lock()
+	f.uploadErr = nil
+	f.mu.Unlock()
+	clk.advance(10 * time.Second)
+
+	if err := doReport(t, r); err != nil {
+		t.Fatalf("second Report: %v", err)
+	}
+	posts, uploads := f.snapshot()
+	if len(posts) != 1 {
+		t.Errorf("want 1 header post (no new header), got %d", len(posts))
+	}
+	if len(uploads) != 2 {
+		t.Fatalf("want 2 upload attempts, got %d", len(uploads))
+	}
+	if uploads[1].ThreadTimestamp != "X" {
+		t.Errorf("second upload thread_ts = %q, want X", uploads[1].ThreadTimestamp)
+	}
+}

--- a/report/slack_test.go
+++ b/report/slack_test.go
@@ -123,6 +123,30 @@ func doReport(t *testing.T, r *SlackReporter) error {
 	})
 }
 
+func TestNewSlackReporter_ThreadTTLDefault(t *testing.T) {
+	tests := []struct {
+		name string
+		opt  time.Duration
+		want time.Duration
+	}{
+		{"unset defaults to 1h", 0, time.Hour},
+		{"negative disables (preserved)", -time.Second, -time.Second},
+		{"custom is kept", 30 * time.Minute, 30 * time.Minute},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewSlackReporter(&SlackReporterOption{
+				Token:     "x",
+				ChannelID: "C123",
+				ThreadTTL: tt.opt,
+			})
+			if r.threadTTL != tt.want {
+				t.Errorf("threadTTL = %v, want %v", r.threadTTL, tt.want)
+			}
+		})
+	}
+}
+
 func TestSlackReporter_FirstReportOpensThread(t *testing.T) {
 	clk := &fakeClock{t: time.Unix(1000, 0)}
 	f := &fakeSlackClient{postTS: []string{"100.1"}}


### PR DESCRIPTION
Each report was uploaded as a separate top-level Slack message, which gets noisy when a pod stays over threshold (the cascade also fires cpu/mem/goroutine together) or when many pods share a channel.

Add an opt-in SlackReporterOption.ThreadTTL: while set, all of a single process's reports go into one thread for the window, measured from when the thread opened; once it elapses the next report opens a fresh thread. Zero/negative (default) preserves the previous behavior.

Slack's UploadFileV2 returns no message timestamp, so a header message is posted via PostMessageContext to obtain a parent ts and files are uploaded as thread replies. ensureThread holds the lock across the header post so concurrent reports open at most one thread per window; a clock interface makes the TTL deterministically testable.